### PR TITLE
Changing Makefile to support install target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SRC_DIR = src
 
-.PHONY: nesasm clean install
+.PHONY: clean install
 
-nesasm:
+install:
 	$(MAKE) -C $(SRC_DIR)
 	mkdir -p bin
 	mv $(SRC_DIR)/nesasm bin/nesasm


### PR DESCRIPTION
Hi! Nothing major-- I just noticed that running `make install` didn't seem to work.

`make nesasm` worked, though. I changed the "nesasm" target to "install" so that the README would be accurate.

BTW: this ran just fine on OSX!
