### PR TITLE
Added support for MacOS in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 SRC_DIR = src
-PREFIX ?= /usr/bin
+uname_s := $(shell uname -s) 
+ ifeq ($(uname_s), Linux)
+	PREFIX ?= /usr/bin
+endif
+ ifeq ($(uname_s), Darwin)
+  	PREFIX ?= /usr/local/bin
+endif
+
 
 .PHONY: nesasm clean install
 


### PR DESCRIPTION
MacOS does not allow users to install programs to /usr/bin, and instead requires users to install programs to /usr/local/bin. This PR adds a check for MacOS in the Makefile which sets the directory to /usr/local/bin